### PR TITLE
feature/main-nav-sticky

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,3 +1,23 @@
 import '../scss/main.scss';
 
 console.log("Hello, Webpack!");
+
+//función para capturar el evento cuando el usuario hace scroll y asignarle la clase sticky
+function sticky() {
+    var header = document.getElementsByClassName('header')[0],
+        top = 0;
+
+    function scroll(event) {
+        var s = document['documentElement' || 'body'].scrollTop;
+        if (s > top) header.classList.add('header__sticky');
+        else header.classList.remove('header__sticky');
+
+    }
+    window.addEventListener('scroll', scroll);
+}
+
+if (document.stickyState == 'complete' || document.stickyState == 'loaded') {
+    sticky();
+} else {
+    window.addEventListener('DOMContentLoaded', sticky);
+}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,23 +1,5 @@
 import '../scss/main.scss';
+import './header-sticky.js'
 
 console.log("Hello, Webpack!");
 
-//función para capturar el evento cuando el usuario hace scroll y asignarle la clase sticky
-function sticky() {
-    var header = document.getElementsByClassName('header')[0],
-        top = 0;
-
-    function scroll(event) {
-        var s = document['documentElement' || 'body'].scrollTop;
-        if (s > top) header.classList.add('header__sticky');
-        else header.classList.remove('header__sticky');
-
-    }
-    window.addEventListener('scroll', scroll);
-}
-
-if (document.stickyState == 'complete' || document.stickyState == 'loaded') {
-    sticky();
-} else {
-    window.addEventListener('DOMContentLoaded', sticky);
-}

--- a/src/js/header-sticky.js
+++ b/src/js/header-sticky.js
@@ -1,0 +1,23 @@
+//función para capturar el evento cuando el usuario hace scroll y asignarle la clase sticky
+function sticky() {
+    
+    const header = document.getElementsByClassName('header')[0],
+    top = 0;
+
+    function scroll(event) {
+        const s = document['documentElement' || 'body'].scrollTop;
+        if (s > top) {
+            header.classList.add('header__sticky');
+        } else {
+            header.classList.remove('header__sticky');
+        }
+
+    }
+    window.addEventListener('scroll', scroll);
+}
+
+if (document.stickyState == 'complete' || document.stickyState == 'loaded') {
+    sticky();
+} else {
+    window.addEventListener('DOMContentLoaded', sticky);
+}

--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -11,6 +11,7 @@
   &__logo--small{
     width: 48px;
     height: 17.5px;
+    margin-left: 10px;
     @include breakpoint (lg) {
       display: none;
       }
@@ -23,9 +24,28 @@
       height: 56px;
     }
   }
+  &__sticky {
+    position:sticky;
+    top: 20px;
+    border: 1px solid #3A3A3A;
+    background-color: white;
+    opacity: 0.8;
+    height: 56px;
+    .header__logo--small {
+      @include breakpoint (lg) {
+        display: inline-block;
+      }
+    }
+    .header__logo {
+      @include breakpoint (lg) {
+        display: none;
+      }
+    }
+  }
   &__hamburguer{
     width: 24px;
     height: 16.6px;
+    margin-right: 10px;
     @include breakpoint (lg) {
       display: none;
     }

--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -27,9 +27,8 @@
   &__sticky {
     position:sticky;
     top: 20px;
-    border: 1px solid #3A3A3A;
-    background-color: white;
-    opacity: 0.8;
+    border: 1px solid var(--black);
+    background-color: var(--white);
     height: 56px;
     .header__logo--small {
       @include breakpoint (lg) {

--- a/templates/page.hbs
+++ b/templates/page.hbs
@@ -17,6 +17,7 @@
     {{{module header}}}
 
     <main>
+      </div>
       {{#each components}}
         {{{module this}}}
       {{/each}}

--- a/templates/page.hbs
+++ b/templates/page.hbs
@@ -17,7 +17,6 @@
     {{{module header}}}
 
     <main>
-      </div>
       {{#each components}}
         {{{module this}}}
       {{/each}}


### PR DESCRIPTION
# FooCamp - TransformaSion

## Trello ticket
https://trello.com/c/6jSvfUJE/16-3-homepage-main-nav-sticky

## Description
Se agrega funcionalidad Sticky para el header en Desktop y Small viewports.

## To reproduce
1. Correr el branch localmente.
2. Agregar contenido de prueba en el archivo page.hbs - main module, para poder generar scroll en la pagina y ver la funcionalidad sticky.
3. Abrir la pagina (http://localhost:8080/jd-page.html)

## Screenshots
Desktop
![image](https://user-images.githubusercontent.com/30637476/130843400-0b264eec-dae6-4e7f-bf27-4c94152f2ced.png)

Small
![image](https://user-images.githubusercontent.com/30637476/130843458-0cc730bb-ab24-4be6-b5a8-4f9a564e8199.png)
